### PR TITLE
Debug XA-30 data handling (case 2, data stored in SpectroscopyData) + decoding fix for writing log files

### DIFF
--- a/readCMRRPhysio.py
+++ b/readCMRRPhysio.py
@@ -279,7 +279,7 @@ def readCMRRPhysio(fn: Union[str,Path], showsamples: int=0, outputpath: str='') 
            (dicomdata.get('ImageType')==['ORIGINAL','PRIMARY','RAWDATA',  'NONE'] and dicomdata.get('SpectroscopyData')) or \
            (dicomdata.get('ImageType') in (['ORIGINAL','PRIMARY','RAWDATA','NONE'], ['ORIGINAL','PRIMARY','OTHER','NONE']) and dicomdata.get(physiotag).private_creator=='SIEMENS MR IMA'):
             if dicomdata.get('SpectroscopyData'):
-                physiodata = struct.unpack('<B', dicomdata['SpectroscopyData'].value)[0]
+                physiodata = dicomdata['SpectroscopyData'].value    # XA30-bug. NB: The original Matlab code casts this to uint8 (i.e. to struct.unpack('<'+len(physiodata)*'B', physiodata)
             else:
                 physiodata = dicomdata[physiotag].value
             rows    = int(dicomdata.AcquisitionNumber)
@@ -314,7 +314,7 @@ def readCMRRPhysio(fn: Union[str,Path], showsamples: int=0, outputpath: str='') 
                 if outputpath:
                     outputfile = Path(outputpath)/filename
                     LOGGER.info(f"Writing physio data to: {outputfile}")
-                    outputfile.write_text(str(logdata))
+                    outputfile.write_text(logdata.decode('UTF-8'))
         else:
             LOGGER.error(f"{fn} is not a valid DICOM format file"); raise RuntimeError
 


### PR DESCRIPTION
This is a straightforward bugfix PR for the python code. The only thing that I was wondering about, is that the Matlab version does some typecasting that I had to skip in the python version (see also issue #347): 

```matlab
    % case 2: up until R017pre6, XA-line ImageType field is wrong, stores in SpectroscopyData
    elseif (isfield(dcmInfo,'ImageType') && strcmp(dcmInfo.ImageType,'ORIGINAL\PRIMARY\RAWDATA\NONE') ... % XA30 bug
        && isfield(dcmInfo,'SpectroscopyData'))
        pdata = typecast(dcmInfo.SpectroscopyData, 'uint8');
```
Why is the typecasting needed? I skipped it and all seems fine without it (and case 1 and case 3 also don't do the typecasting)